### PR TITLE
Trailing slash results in 404 page

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -3,7 +3,7 @@
 * Tried upgrading to newest version of Fluent Assertions, to see if your issue has already been resolved and released?
 * Checked existing open *and* closed [issues](https://github.com/fluentassertions/fluentassertions/issues?utf8=%E2%9C%93&q=is%3Aissue), to see if the issue has already been reported?
 * Tried reproducing your problem in a new isolated project?
-* Read the [documentation](https://fluentassertions.com/introduction/)?
+* Read the [documentation](https://fluentassertions.com/introduction)?
 * Considered if this is a general question and not a bug?. For general questions please use [StackOverflow](https://stackoverflow.com/questions/tagged/fluent-assertions?mixed=1).
 
 ### Description


### PR DESCRIPTION
Noticed that when going to https://fluentassertions.com/introduction/ I get a 404-page in response. If I remove the trailing slash it works. 
I guess the best solution is to make it work with and without trailing slash but this is at least one way of making the Issue template not pointing to a 404-page.

## IMPORTANT 

* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by a new or existing set of unit tests which follow the Arrange-Act-Assert syntax such as is used [in this example](https://github.com/fluentassertions/fluentassertions/blob/daaf35b9b59b622c96d0c034e8972a020b2bee55/Tests/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs#L33).
* [ ] If the contribution adds a feature or fixes a bug, please update [**the release notes**](https://github.com/fluentassertions/fluentassertions/tree/master/docs), which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the contribution changes the public API the changes needs to be included by running `AcceptApiChanges.ps1`/`AcceptApiChanges.sh`.
* [ ] If the contribution affects [the documentation](https://github.com/fluentassertions/fluentassertions/tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).